### PR TITLE
Create a full name with the full name of the existing session field

### DIFF
--- a/support.php
+++ b/support.php
@@ -138,7 +138,7 @@ if (isset($_POST['send_ticket'])) {
                     </div>
                     <div class="mb-3">
                         <label for="created_by" class="form-label">Fullname</label>
-                        <input type="text" class="form-control" id="created_by" name="created_by" required placeholder="John Doe">
+                        <input type="text" class="form-control" id="created_by" name="created_by" value="<?= $_SESSION['user']['fullname'] ?>" readonly>
                     </div>
                     <div class="mb-3">
                         <label for="reported_email" class="form-label">Email address</label>


### PR DESCRIPTION
This pull request includes a small but important change to the `support.php` file. The change ensures that the `created_by` field is pre-filled with the current user's full name from the session and is set to read-only.

* [`support.php`](diffhunk://#diff-2da57ac63ab4cbbade48b3823383688d0540d818a767a98e5f3e467c9a0fb608L141-R141): Updated the `created_by` input field to use the current user's full name from the session and made it read-only.

Sorry the first task 1 was almost forgotten 🙏