### PR TITLE
Update event registration messages for clarity

### DIFF
--- a/event_register.php
+++ b/event_register.php
@@ -166,13 +166,6 @@ $events = $eventController->get();
                                     </div>
                                 </div>
 
-                            <?php else : ?>
-
-                                <div class="alert alert-info w-100" role="alert">
-                                    All webinar has been published
-                                </div>
-
-
                             <?php endif; ?>
 
                         <?php endforeach; ?>
@@ -180,7 +173,7 @@ $events = $eventController->get();
                     <?php else : ?>
 
                         <div class="alert alert-info w-100" role="alert">
-                            No ticket found
+                            No event found
                         </div>
 
                     <?php endif; ?>


### PR DESCRIPTION
This pull request includes changes to the `event_register.php` file to improve the user interface messages for event registration. The most important changes include removing an unnecessary alert message and updating another alert message for better clarity.

Improvements to user interface messages:

* Removed an unnecessary alert message that indicated all webinars had been published.
* Updated the alert message from "No ticket found" to "No event found" for better clarity.